### PR TITLE
Fix some NPEs

### DIFF
--- a/src/matcher/type/Analysis.java
+++ b/src/matcher/type/Analysis.java
@@ -2008,6 +2008,9 @@ class Analysis {
 		while ((in = positionsToTrace.poll()) != null) {
 			int pos = il.indexOf(in);
 			Frame<SourceValue> frame = frames[pos];
+			if (frame == null) {
+				continue;
+			}
 			int stackConsumed = getStackDemand(in, frame);
 
 			for (int i = 0; i < stackConsumed; i++) {

--- a/src/matcher/type/ClassEnvironment.java
+++ b/src/matcher/type/ClassEnvironment.java
@@ -508,6 +508,9 @@ public class ClassEnvironment implements ClassEnv {
 		} else { // determine outer class by outer$inner name pattern
 			for (InnerClassNode icn : cn.innerClasses) {
 				if (icn.name.equals(cn.name)) {
+					if (icn.outerName == null) {
+						return;
+					}
 					addOuterClass(cls, icn.outerName, true);
 					return;
 				}


### PR DESCRIPTION
The one involving inner classes appeared when it encountered
an anonymous inner class. `blah.blah$1` made the outerName null.

I have no idea what's up with the frame analysis, but skipping null
frames let everything run fine.